### PR TITLE
Add license and package metadata to doublets-ffi

### DIFF
--- a/doublets-ffi/Cargo.toml
+++ b/doublets-ffi/Cargo.toml
@@ -2,6 +2,15 @@
 name = "doublets-ffi"
 version = "0.1.0"
 edition = "2021"
+authors = [
+    "uselessgoddess",
+    "Linksplatform Team <linksplatformtechnologies@gmail.com>"
+]
+license = "Unlicense"
+repository = "https://github.com/linksplatform/doublets-rs"
+homepage = "https://github.com/linksplatform/doublets-rs"
+description = "FFI bindings for the doublets library"
+readme = "../README.md"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]


### PR DESCRIPTION
## Summary
- Add Unlicense license to doublets-ffi/Cargo.toml to match repository LICENSE file
- Add authors, repository, homepage, description and readme fields to package metadata
- Ensures proper license information is displayed on crates.io when package is published

## Test plan
- [x] Verify Cargo.toml syntax is valid
- [x] Confirm license field matches repository LICENSE file (Unlicense)
- [x] Ensure all required package metadata fields are present for crates.io publication

Fixes #21

🤖 Generated with [Claude Code](https://claude.ai/code)