### PR TITLE
Add inline attributes for performance optimization

### DIFF
--- a/doublets/Cargo.toml
+++ b/doublets/Cargo.toml
@@ -39,7 +39,7 @@ rayon = { version = "1.5.3", optional = true }
 mem = []
 num = []
 data = []
-more-inline = []
+inline-more = []
 small-search = ["smallvec"]
 # todo: may be internal_platform
 platform = ["mem", "num", "data"]

--- a/doublets/src/data/traits.rs
+++ b/doublets/src/data/traits.rs
@@ -42,6 +42,7 @@ pub trait Doublets<T: LinkType>: Links<T> {
         self.count_links(&query.to_query()[..])
     }
 
+    #[inline(always)]
     fn count(&self) -> T
     where
         Self: Sized,
@@ -249,6 +250,7 @@ pub trait Doublets<T: LinkType>: Links<T> {
         self.delete_by([index])
     }
 
+    #[inline]
     fn try_get_link(&self, index: T) -> Result<Link<T>, Error<T>> {
         self.get_link(index).ok_or(Error::NotExists(index))
     }
@@ -552,14 +554,17 @@ pub trait Doublets<T: LinkType>: Links<T> {
 }
 
 impl<T: LinkType, All: Doublets<T> + ?Sized> Links<T> for Box<All> {
+    #[inline(always)]
     fn constants(&self) -> &LinksConstants<T> {
         (**self).constants()
     }
 
+    #[inline(always)]
     fn count_links(&self, query: &[T]) -> T {
         (**self).count_links(query)
     }
 
+    #[inline(always)]
     fn create_links(
         &mut self,
         query: &[T],
@@ -568,10 +573,12 @@ impl<T: LinkType, All: Doublets<T> + ?Sized> Links<T> for Box<All> {
         (**self).create_links(query, handler)
     }
 
+    #[inline(always)]
     fn each_links(&self, query: &[T], handler: ReadHandler<'_, T>) -> Flow {
         (**self).each_links(query, handler)
     }
 
+    #[inline(always)]
     fn update_links(
         &mut self,
         query: &[T],
@@ -581,6 +588,7 @@ impl<T: LinkType, All: Doublets<T> + ?Sized> Links<T> for Box<All> {
         (**self).update_links(query, change, handler)
     }
 
+    #[inline(always)]
     fn delete_links(
         &mut self,
         query: &[T],
@@ -591,6 +599,7 @@ impl<T: LinkType, All: Doublets<T> + ?Sized> Links<T> for Box<All> {
 }
 
 impl<T: LinkType, All: Doublets<T> + ?Sized> Doublets<T> for Box<All> {
+    #[inline(always)]
     fn get_link(&self, index: T) -> Option<Link<T>> {
         (**self).get_link(index)
     }
@@ -655,7 +664,7 @@ impl<T: LinkType, All: Doublets<T> + Sized> DoubletsExt<T> for All {
 
     type ImplIterEach = impl Iterator<Item = Link<T>> + ExactSizeIterator + DoubleEndedIterator;
 
-    #[cfg_attr(feature = "more-inline", inline)]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn each_iter(&self, query: impl ToQuery<T>) -> Self::ImplIterEach {
         let cap = self.count_by(query.to_query()).as_usize();
 
@@ -681,7 +690,7 @@ impl<T: LinkType, All: Doublets<T> + Sized> DoubletsExt<T> for All {
         impl Iterator<Item = Link<T>> + ExactSizeIterator + DoubleEndedIterator;
 
     #[cfg(feature = "small-search")]
-    #[cfg_attr(feature = "more-inline", inline)]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn each_iter_small(&self, query: impl ToQuery<T>) -> Self::ImplIterEachSmall {
         // fixme: later use const generics
         const SIZE_HINT: usize = 2;

--- a/doublets/src/mem/split/store.rs
+++ b/doublets/src/mem/split/store.rs
@@ -307,11 +307,13 @@ impl<
         Ok(())
     }
 
+    #[cfg_attr(feature = "inline-more", inline)]
     fn total(&self) -> T {
         let header = self.get_header();
         header.allocated - header.free
     }
 
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_unused(&self, link: T) -> bool {
         let header = self.get_header();
         if link <= header.allocated && header.first_free != link {
@@ -330,6 +332,7 @@ impl<
         self.is_unused(link)
     }
 
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn exists(&self, link: T) -> bool {
         let constants = self.constants();
         let header = self.get_header();
@@ -544,6 +547,7 @@ impl<
     UL: SplitList<T>,
 > Links<T> for Store<T, MD, MI, IS, ES, IT, ET, UL>
 {
+    #[inline(always)]
     fn constants(&self) -> &LinksConstants<T> {
         &self.constants
     }

--- a/doublets/src/mem/unit/store.rs
+++ b/doublets/src/mem/unit/store.rs
@@ -186,11 +186,13 @@ impl<T: LinkType, M: RawMem<LinkPart<T>>, TS: UnitTree<T>, TT: UnitTree<T>, TU: 
         self.attach_target_unchecked(root, index);
     }
 
+    #[cfg_attr(feature = "inline-more", inline)]
     fn get_total(&self) -> T {
         let header = self.get_header();
         header.allocated - header.free
     }
 
+    #[cfg_attr(feature = "inline-more", inline)]
     fn is_unused(&self, link: T) -> bool {
         let header = self.get_header();
         if link <= header.allocated && header.first_free != link {
@@ -205,6 +207,7 @@ impl<T: LinkType, M: RawMem<LinkPart<T>>, TS: UnitTree<T>, TT: UnitTree<T>, TU: 
         }
     }
 
+    #[cfg_attr(feature = "inline-more", inline)]
     fn exists(&self, link: T) -> bool {
         let constants = self.constants();
         let header = self.get_header();
@@ -323,6 +326,7 @@ impl<T: LinkType, M: RawMem<LinkPart<T>>, TS: UnitTree<T>, TT: UnitTree<T>, TU: 
 impl<T: LinkType, M: RawMem<LinkPart<T>>, TS: UnitTree<T>, TT: UnitTree<T>, TU: UnitList<T>>
     Links<T> for Store<T, M, TS, TT, TU>
 {
+    #[inline(always)]
     fn constants(&self) -> &LinksConstants<T> {
         &self.constants
     }


### PR DESCRIPTION
## Summary

This PR implements the inline initiative as requested in issue #8, adding `#[inline]` attributes to optimize function inlining throughout the codebase.

## Changes Made

### 🔧 Feature Configuration
- **Fixed feature name**: Changed `more-inline` to `inline-more` in `Cargo.toml` to match issue specification
- **Updated existing attributes**: Fixed existing `cfg_attr` directives to use the correct feature name

### ⚡ Inline Attributes Added

#### `#[inline]` - Obvious functions
- `try_get_link()` in `data/traits.rs` - Simple delegation that converts `Option` to `Result`

#### `#[inline(always)]` - Hard delegations  
- `constants()` - All implementations that simply return `&self.constants`
- `count()` - Simple delegation to `count_by([])`
- All `Box<dyn Trait>` implementations - Direct delegations to the boxed value:
  - `count_links()`
  - `create_links()`  
  - `each_links()`
  - `update_links()`
  - `delete_links()`
  - `get_link()`

#### `#[cfg_attr(feature = "inline-more", inline)]` - Questionable/internal functions
- `is_unused()` - Internal function for checking unused links (both unit and split store)
- `exists()` - Internal function for existence checks (both unit and split store)  
- `get_total()`/`total()` - Internal functions for getting total counts
- Updated existing conditional inlines in iterator methods

## Files Modified

- `doublets/Cargo.toml` - Fixed feature name
- `doublets/src/data/traits.rs` - Added inline attributes to trait methods and Box implementations
- `doublets/src/mem/unit/store.rs` - Added inline attributes to internal helper methods
- `doublets/src/mem/split/store.rs` - Added inline attributes to internal helper methods

## Testing

The changes preserve all existing functionality while providing compiler hints for better inlining. The conditional `inline-more` feature allows users to opt into more aggressive inlining for performance-critical scenarios.

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)