### PR TITLE
docs: update README stable Rust guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Check documentation badges
         run: rust-script scripts/check-readme-badges.rs
 
+      - name: Check documented toolchain guidance
+        run: rust-script scripts/check-toolchain-docs.rs
+
   # Test runs independently of changelog check
   # === TEST ===
   test:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T22:35:27.255Z for PR creation at branch issue-55-c5a7335ee9a7 for issue https://github.com/linksplatform/doublets-rs/issues/55

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,18 @@ Thank you for your interest in contributing! This document provides guidelines a
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
 
-   The project uses a specific nightly toolchain configured in `rust-toolchain.toml`:
+   The project uses the stable toolchain configured in `rust-toolchain.toml`:
+
    ```toml
    [toolchain]
-   channel = "nightly-2022-08-22"
+   channel = "stable"
+   ```
+
+   The `doublets` crate declares its minimum supported Rust version in
+   `doublets/Cargo.toml`:
+
+   ```toml
+   rust-version = "1.85"
    ```
 
 3. **Install development tools**
@@ -69,10 +77,14 @@ Thank you for your interest in contributing! This document provides guidelines a
    cargo clippy --all --tests --all-features
 
    # Check file sizes
-   node scripts/check-file-size.mjs
+   rust-script scripts/check-file-size.rs
+
+   # Check README badges and toolchain guidance
+   rust-script scripts/check-readme-badges.rs
+   rust-script scripts/check-toolchain-docs.rs
 
    # Run all checks together
-   cargo fmt --check && cargo clippy --all --tests --all-features && node scripts/check-file-size.mjs
+   cargo fmt --all -- --check && cargo clippy --all-targets --all-features && rust-script scripts/check-file-size.rs && rust-script scripts/check-readme-badges.rs && rust-script scripts/check-toolchain-docs.rs
    ```
 
 4. **Run tests**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "doublets"
-version = "0.1.0-pre+beta.15"
+version = "0.3.0"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/README.md
+++ b/README.md
@@ -34,13 +34,16 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-doublets = "0.1.0-pre"
+doublets = "0.3.0"
 ```
 
-**Note:** This crate requires nightly Rust due to usage of experimental features.
+Use stable Rust 1.85 or newer. The repository's `rust-toolchain.toml` selects the
+stable channel, and the crate declares `rust-version = "1.85"` in
+`doublets/Cargo.toml`.
 
 ```bash
-rustup default nightly
+rustup toolchain install stable
+cargo +stable build
 ```
 
 ## Example

--- a/changelog.d/20260529_223900_issue_55_toolchain_docs.md
+++ b/changelog.d/20260529_223900_issue_55_toolchain_docs.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- Updated README installation guidance to use doublets 0.3.0 and stable Rust 1.85 or newer.
+- Added a CI documentation check that prevents stale nightly Rust and crate version guidance from returning.

--- a/scripts/check-toolchain-docs.rs
+++ b/scripts/check-toolchain-docs.rs
@@ -1,0 +1,180 @@
+#!/usr/bin/env rust-script
+//! Check that documentation matches the crate version and Rust toolchain.
+//!
+//! Usage: rust-script scripts/check-toolchain-docs.rs
+
+use std::fs;
+use std::path::Path;
+use std::process::exit;
+
+struct Violation {
+    file: &'static str,
+    line: Option<usize>,
+    message: String,
+}
+
+fn read(path: &'static str) -> String {
+    fs::read_to_string(Path::new(path)).unwrap_or_else(|error| {
+        eprintln!("Failed to read {path}: {error}");
+        exit(1);
+    })
+}
+
+fn quoted_value(file: &'static str, contents: &str, key: &str) -> String {
+    for line in contents.lines() {
+        let line = line.trim();
+        let Some(value) = line.strip_prefix(&format!("{key} = ")) else {
+            continue;
+        };
+
+        if let Some(value) = value.strip_prefix('"').and_then(|value| value.split('"').next()) {
+            return value.to_string();
+        }
+    }
+
+    eprintln!("Failed to find `{key}` in {file}");
+    exit(1);
+}
+
+fn first_line_containing(contents: &str, needle: &str) -> Option<usize> {
+    contents
+        .lines()
+        .position(|line| line.contains(needle))
+        .map(|index| index + 1)
+}
+
+fn require_contains(
+    violations: &mut Vec<Violation>,
+    file: &'static str,
+    contents: &str,
+    needle: &str,
+    message: &str,
+) {
+    if !contents.contains(needle) {
+        violations.push(Violation {
+            file,
+            line: None,
+            message: message.to_string(),
+        });
+    }
+}
+
+fn reject_contains(
+    violations: &mut Vec<Violation>,
+    file: &'static str,
+    contents: &str,
+    needle: &str,
+    message: &str,
+) {
+    if let Some(line) = first_line_containing(contents, needle) {
+        violations.push(Violation {
+            file,
+            line: Some(line),
+            message: message.to_string(),
+        });
+    }
+}
+
+fn main() {
+    println!("\nChecking documented Rust toolchain and crate version...\n");
+
+    let cargo_toml = read("doublets/Cargo.toml");
+    let crate_version = quoted_value("doublets/Cargo.toml", &cargo_toml, "version");
+    let rust_version = quoted_value("doublets/Cargo.toml", &cargo_toml, "rust-version");
+
+    let rust_toolchain = read("rust-toolchain.toml");
+    let toolchain_channel = quoted_value("rust-toolchain.toml", &rust_toolchain, "channel");
+
+    let readme = read("README.md");
+    let contributing = read("CONTRIBUTING.md");
+
+    let mut violations = Vec::new();
+
+    require_contains(
+        &mut violations,
+        "README.md",
+        &readme,
+        &format!("doublets = \"{crate_version}\""),
+        &format!("README installation snippet must use doublets = \"{crate_version}\""),
+    );
+    require_contains(
+        &mut violations,
+        "README.md",
+        &readme,
+        &format!("stable Rust {rust_version} or newer"),
+        &format!("README must document stable Rust {rust_version} or newer"),
+    );
+    require_contains(
+        &mut violations,
+        "README.md",
+        &readme,
+        "rustup toolchain install stable",
+        "README must show stable toolchain installation",
+    );
+    reject_contains(
+        &mut violations,
+        "README.md",
+        &readme,
+        "0.1.0-pre",
+        "README contains the obsolete pre-release dependency version",
+    );
+    reject_contains(
+        &mut violations,
+        "README.md",
+        &readme,
+        "requires nightly Rust",
+        "README still says nightly Rust is required",
+    );
+    reject_contains(
+        &mut violations,
+        "README.md",
+        &readme,
+        "rustup default nightly",
+        "README still instructs users to switch to nightly Rust",
+    );
+
+    require_contains(
+        &mut violations,
+        "CONTRIBUTING.md",
+        &contributing,
+        &format!("channel = \"{toolchain_channel}\""),
+        &format!("CONTRIBUTING.md must document the `{toolchain_channel}` toolchain channel"),
+    );
+    require_contains(
+        &mut violations,
+        "CONTRIBUTING.md",
+        &contributing,
+        &format!("rust-version = \"{rust_version}\""),
+        &format!("CONTRIBUTING.md must document rust-version = \"{rust_version}\""),
+    );
+    reject_contains(
+        &mut violations,
+        "CONTRIBUTING.md",
+        &contributing,
+        "specific nightly toolchain",
+        "CONTRIBUTING.md still describes the project as nightly-only",
+    );
+    reject_contains(
+        &mut violations,
+        "CONTRIBUTING.md",
+        &contributing,
+        "nightly-2022-08-22",
+        "CONTRIBUTING.md still references the old nightly toolchain",
+    );
+
+    if violations.is_empty() {
+        println!("Documentation matches doublets/Cargo.toml and rust-toolchain.toml\n");
+        return;
+    }
+
+    println!("Found stale toolchain documentation:\n");
+    for violation in &violations {
+        match violation.line {
+            Some(line) => println!("  {}:{}: {}", violation.file, line, violation.message),
+            None => println!("  {}: {}", violation.file, violation.message),
+        }
+    }
+    println!();
+
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- Update README installation guidance to use `doublets = "0.3.0"`.
- Replace stale nightly Rust instructions with stable Rust 1.85+ guidance from `doublets/Cargo.toml` and `rust-toolchain.toml`.
- Add `scripts/check-toolchain-docs.rs` and wire it into CI so stale README/toolchain guidance is caught automatically.
- Refresh CONTRIBUTING checks and Cargo.lock package metadata to match the current crate version.

## Reproduction
Before the documentation update, the new guard failed with the stale guidance:

```bash
rust-script scripts/check-toolchain-docs.rs
```

It reported the old `doublets = "0.1.0-pre"` snippet, the nightly Rust requirement, and the old contributing toolchain text.

## Validation
- `rust-script scripts/check-toolchain-docs.rs`
- `rust-script scripts/check-readme-badges.rs`
- `rust-script scripts/check-file-size.rs`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features --verbose`
- `cargo test --doc --verbose`
- `GITHUB_BASE_REF=main rust-script scripts/check-changelog-fragment.rs`
- `GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=issue-55-c5a7335ee9a7 GITHUB_BASE_REF=main rust-script scripts/check-version-modification.rs`

Fixes #55